### PR TITLE
Add a note to clarify the dependency on xz

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,3 +156,10 @@ options:
 
   -?, --help                   print this message
 ```
+
+# external dependency
+`repaq` makes a system call in order to run the xz compression tool available on GNU/Linux systems. If xz isn't installed, `repaq` will fail with the message: 
+
+```
+failed to call xz, please confirm that xz is installed in your system
+```


### PR DESCRIPTION
From the original README description, it looks like repaq implements the xz compression itself. 
Instead, it makes a call to an external tool, and this seems to be something important to let the users know. 
Therefore I'd like to suggest this small change.